### PR TITLE
DSPDC-802 Write root-level attributes into a separate directory

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,15 @@
 val betterFilesVersion = "3.8.0"
-val catsEffectVersion = "2.1.0"
-val circeVersion = "0.12.3"
+val catsEffectVersion = "2.1.1"
+val circeVersion = "0.13.0"
 val declineVersion = "1.0.0"
 val fs2Version = "2.2.2"
 val jettisonVersion = "1.4.0"
 val logbackVersion = "1.2.3"
-val log4CatsVersion = "1.0.0"
-val woodstoxVersion = "6.0.2"
+val log4CatsVersion = "1.0.1"
+val woodstoxVersion = "6.0.3"
 
 // Testing.
-val scalaTestVersion = "3.0.8"
+val scalaTestVersion = "3.1.0"
 
 lazy val `monster-xml-to-json-list` = project
   .in(file("."))

--- a/src/test/resources/inputs/empty.xml
+++ b/src/test/resources/inputs/empty.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0"?>
-<Tests xmlns="http://www.adatum.com">
-</Tests>

--- a/src/test/resources/outputs/many-tags.json
+++ b/src/test/resources/outputs/many-tags.json
@@ -1,2 +1,3 @@
-{"Test": {"@id": "1", "name": {"$": "First tag"}, "Tests": {"@xmlns": {"$": "http://www.adatum.com"}}}}
-{"Test": {"@id": "2", "name": {"$": "Second tag"}, "Tests": {"@xmlns": {"$": "http://www.adatum.com"}}}}
+{"Tests": {"@xmlns": {"$": "http://www.adatum.com"}}}
+{"Test": {"@id": "1", "name": {"$": "First tag"}}}
+{"Test": {"@id": "2", "name": {"$": "Second tag"}}}

--- a/src/test/resources/outputs/mixed-tags.json
+++ b/src/test/resources/outputs/mixed-tags.json
@@ -1,8 +1,9 @@
-{"Test": {"Tests": {"@xmlns": {"$": "http://www.adatum.com"}}, "@id": "1", "name": {"$": "First tag"}}}
-{"Test": {"Tests": {"@xmlns": {"$": "http://www.adatum.com"}}, "@id": "2", "name": {"$": "Second tag"}}}
-{"Test2": {"Tests": {"@xmlns": {"$": "http://www.adatum.com"}}, "@name": "A", "id": {"$": "123"}}}
-{"Test": {"Tests": {"@xmlns": {"$": "http://www.adatum.com"}}, "@id": "3", "name": {"$": "Third tag"}}}
-{"Test2": {"Tests": {"@xmlns": {"$": "http://www.adatum.com"}}, "@name": "B", "id": {"$": "456"}}}
-{"Test2": {"Tests": {"@xmlns": {"$": "http://www.adatum.com"}}, "@name": "C", "id": {"$": "789"}}}
-{"Test2": {"Tests": {"@xmlns": {"$": "http://www.adatum.com"}}, "@name": "D", "id": {"$": "000"}}}
-{"Test3": {"Tests": {"@xmlns": {"$": "http://www.adatum.com"}}, "@foo": "bar"}}
+{"Tests": {"@xmlns": {"$": "http://www.adatum.com"}}}
+{"Test": {"@id": "1", "name": {"$": "First tag"}}}
+{"Test": {"@id": "2", "name": {"$": "Second tag"}}}
+{"Test2": {"@name": "A", "id": {"$": "123"}}}
+{"Test": {"@id": "3", "name": {"$": "Third tag"}}}
+{"Test2": {"@name": "B", "id": {"$": "456"}}}
+{"Test2": {"@name": "C", "id": {"$": "789"}}}
+{"Test2": {"@name": "D", "id": {"$": "000"}}}
+{"Test3": {"@foo": "bar"}}

--- a/src/test/resources/outputs/nested-repeated.json
+++ b/src/test/resources/outputs/nested-repeated.json
@@ -1,1 +1,2 @@
-{"Test": {"Tests": {"@xmlns": {"$": "http://www.adatum.com"}}, "@TestId": "0004", "@TestType": "GUI", "Nested": [{"Nested2": {"Info": {"$": "Testing nested layers"}}, "NestedInput": {"$": "Nested Input"}, "NestedOutput": {"$": "Nested Output"}}, {"Nested2": [{"Info": {"$": "Testing nested repeated layers"}}, {"Info": {"$": "All the layers of nested-repeated!"}, "Foo": {"$": "Bar"}}]}]}}
+{"Tests": {"@xmlns": {"$": "http://www.adatum.com"}}}
+{"Test": {"@TestId": "0004", "@TestType": "GUI", "Nested": [{"Nested2": {"Info": {"$": "Testing nested layers"}}, "NestedInput": {"$": "Nested Input"}, "NestedOutput": {"$": "Nested Output"}}, {"Nested2": [{"Info": {"$": "Testing nested repeated layers"}}, {"Info": {"$": "All the layers of nested-repeated!"}, "Foo": {"$": "Bar"}}]}]}}

--- a/src/test/resources/outputs/nested.json
+++ b/src/test/resources/outputs/nested.json
@@ -1,1 +1,2 @@
-{"Test": {"Tests": {"@xmlns": {"$": "http://www.adatum.com"}},"@TestId": "0004", "@TestType": "GUI", "Nested": {"Nested2": {"Info": {"$": "Testing nested layers"}}, "NestedInput": {"$": "Nested Input"}, "NestedOutput":{"$": "Nested Output"}}}}
+{"Tests": {"@xmlns": {"$": "http://www.adatum.com"}}}
+{"Test": {"@TestId": "0004", "@TestType": "GUI", "Nested": {"Nested2": {"Info": {"$": "Testing nested layers"}}, "NestedInput": {"$": "Nested Input"}, "NestedOutput":{"$": "Nested Output"}}}}

--- a/src/test/resources/outputs/root-attributes.json
+++ b/src/test/resources/outputs/root-attributes.json
@@ -1,2 +1,3 @@
-{"Test": {"Tests": {"@xmlns": {"$": "http://www.adatum.com"}, "@globalProperty": "global", "@otherProperty": "other"}, "@id": "1", "name": {"$": "First tag"}}}
-{"Test": {"Tests": {"@xmlns": {"$": "http://www.adatum.com"}, "@globalProperty": "global", "@otherProperty": "other"}, "@id": "2", "name": {"$": "Second tag"}}}
+{"Tests": {"@xmlns": {"$": "http://www.adatum.com"}, "@globalProperty": "global", "@otherProperty": "other"}}
+{"Test": {"@id": "1", "name": {"$": "First tag"}}}
+{"Test": {"@id": "2", "name": {"$": "Second tag"}}}

--- a/src/test/resources/outputs/simple.json
+++ b/src/test/resources/outputs/simple.json
@@ -1,1 +1,2 @@
-{"Test": {"@id": "1", "name": {"$": "Minimal XML"}, "Tests": {"@xmlns": {"$": "http://www.adatum.com"}}}}
+{"Tests": {"@xmlns": {"$": "http://www.adatum.com"}}}
+{"Test": {"@id": "1", "name": {"$": "Minimal XML"}}}

--- a/src/test/scala/org/broadinstitute/monster/extractors/xml/XmlExtractorSpec.scala
+++ b/src/test/scala/org/broadinstitute/monster/extractors/xml/XmlExtractorSpec.scala
@@ -67,55 +67,54 @@ class XmlExtractorSpec extends AnyFlatSpec with Matchers with EitherValues {
     "convert XML to JSON",
     "simple",
     tagsPerFile = 1,
-    expectedParts = List("Test/part-1.json" -> 1)
+    expectedParts = List(
+      "Tests/part-1.json" -> 1,
+      "Test/part-1.json" -> 1
+    )
   )
   it should behave like conversionTest(
     "convert repeated top-level tags into repeated objects",
     "many-tags",
     tagsPerFile = 1,
-    expectedParts = List("Test/part-1.json" -> 1, "Test/part-2.json" -> 1)
+    expectedParts =
+      List("Tests/part-1.json" -> 1, "Test/part-1.json" -> 1, "Test/part-2.json" -> 1)
   )
   it should behave like conversionTest(
     "support user-specified chunk counts for top-level repeated objects",
     "many-tags",
     tagsPerFile = 2,
-    expectedParts = List("Test/part-1.json" -> 2)
+    expectedParts = List("Tests/part-1.json" -> 1, "Test/part-1.json" -> 2)
   )
   it should behave like conversionTest(
     "terminate if there are fewer tags in the document than the max count",
     "many-tags",
     tagsPerFile = 100,
-    expectedParts = List("Test/part-1.json" -> 2)
+    expectedParts = List("Tests/part-1.json" -> 1, "Test/part-1.json" -> 2)
   )
   it should behave like conversionTest(
     "convert nested tags into nested objects",
     "nested",
     tagsPerFile = 1,
-    expectedParts = List("Test/part-1.json" -> 1)
+    expectedParts = List("Tests/part-1.json" -> 1, "Test/part-1.json" -> 1)
   )
   it should behave like conversionTest(
     "convert repeated nested tags into arrays",
     "nested-repeated",
     tagsPerFile = 1,
-    expectedParts = List("Test/part-1.json" -> 1)
+    expectedParts = List("Tests/part-1.json" -> 1, "Test/part-1.json" -> 1)
   )
   it should behave like conversionTest(
-    "include root-level attributes in top-level objects",
+    "output root-level attributes",
     "root-attributes",
     tagsPerFile = 2,
-    expectedParts = List("Test/part-1.json" -> 2)
-  )
-  it should behave like conversionTest(
-    "not write output if there is no XML to extract",
-    "empty",
-    tagsPerFile = 1,
-    expectedParts = Nil
+    expectedParts = List("Tests/part-1.json" -> 1, "Test/part-1.json" -> 2)
   )
   it should behave like conversionTest(
     "handle multiple top-level tag types in one document",
     "mixed-tags",
     tagsPerFile = 2,
     expectedParts = List(
+      "Tests/part-1.json" -> 1,
       "Test/part-1.json" -> 2,
       "Test2/part-1.json" -> 1,
       "Test/part-2.json" -> 1,

--- a/src/test/scala/org/broadinstitute/monster/extractors/xml/XmlExtractorSpec.scala
+++ b/src/test/scala/org/broadinstitute/monster/extractors/xml/XmlExtractorSpec.scala
@@ -4,11 +4,13 @@ import better.files.File
 import cats.effect.{Blocker, ContextShift, IO}
 import cats.implicits._
 import io.circe.Json
-import org.scalatest.{EitherValues, FlatSpec, Matchers}
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext
 
-class XmlExtractorSpec extends FlatSpec with Matchers with EitherValues {
+class XmlExtractorSpec extends AnyFlatSpec with Matchers with EitherValues {
   behavior of "XmlExtractor"
 
   private implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)


### PR DESCRIPTION
The root-level attributes will now be written to:
```
<outDir>/<RootTagName>/part-1.json
```
I tried to make it write to:
```
<outDir>/<RootTagName>.json
```
But the existing code _really_ doesn't want to let that work. The way it works now will work well-enough for ClinVar, it'll just look strange.