### PR TITLE
DSPDC-941 Bump plugins.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,4 +14,4 @@ resolvers += Resolver.url(
   new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
 )(publishPatterns)
 
-addSbtPlugin("org.broadinstitute.monster" % "sbt-plugins-core" % "0.13.0")
+addSbtPlugin("org.broadinstitute.monster" % "sbt-plugins-core" % "0.14.0")


### PR DESCRIPTION
Somehow the Docker images produced by 0.13.0 of our plugins are just fundamentally broken.