### PR TITLE
DSPDC-1151 Fix memory settings

### DIFF
--- a/argo/templates/template.yaml
+++ b/argo/templates/template.yaml
@@ -65,6 +65,9 @@ spec:
             args+=(--gunzip-input)
           fi
 
+          # Clear the output dir to avoid corrupted outputs.
+          rm -rf /out/*
+
           # Prevent the heap from consuming all of the pod's memory.
           declare -r java_mem=$(((${MEM_GIB} - 1)))
           export JAVA_OPTS="-Xmx${java_mem}g -Xms${java_mem}g"

--- a/argo/templates/template.yaml
+++ b/argo/templates/template.yaml
@@ -13,7 +13,7 @@ spec:
           - name: output-pvc-name
           - name: objects-per-part
           - name: gunzip
-          - name: memory-gib
+          - name: memory-mib
           - name: cpu-m
       volumes:
         - name: in
@@ -23,17 +23,17 @@ spec:
         - name: out
           persistentVolumeClaim:
             claimName: '{{ "{{inputs.parameters.output-pvc-name}}" }}'
-      {{- $mem := "{{inputs.parameters.memory-gib}}" }}
+      {{- $mem := "{{inputs.parameters.memory-mib}}" }}
       {{- $cpu := "{{inputs.parameters.cpu-m}}" }}
       podSpecPatch: |
         containers:
           - name: main
             resources:
               requests:
-                memory: {{ $mem }}Gi
+                memory: {{ $mem }}Mi
                 cpu: {{ $cpu }}m
               limits:
-                memory: {{ $mem }}Gi
+                memory: {{ $mem }}Mi
                 cpu: {{ $cpu }}m
       script:
         image: us.gcr.io/broad-dsp-gcr-public/xml-to-json-list-clp:{{ $version }}
@@ -44,7 +44,7 @@ spec:
           - name: out
             mountPath: /out
         env:
-          - name: MEM_GIB
+          - name: MEM_MIB
             value: {{ $mem | quote }}
           - name: INPUT
             value: {{ "/in/{{inputs.parameters.input-xml-path}}" }}
@@ -69,6 +69,6 @@ spec:
           rm -rf /out/*
 
           # Prevent the heap from consuming all of the pod's memory.
-          declare -r java_mem=$(((${MEM_GIB} - 1)))
-          export JAVA_OPTS="-Xmx${java_mem}g -Xms${java_mem}g"
+          declare -r java_mem=$(((${MEM_MIB} - 1024)))
+          export JAVA_OPTS="-Xmx${java_mem}m -Xms${java_mem}m"
           /app/bin/xml-to-json-list-clp ${args[@]}

--- a/argo/templates/template.yaml
+++ b/argo/templates/template.yaml
@@ -13,7 +13,7 @@ spec:
           - name: output-pvc-name
           - name: objects-per-part
           - name: gunzip
-          - name: memory-mib
+          - name: memory-gib
           - name: cpu-m
       volumes:
         - name: in
@@ -23,17 +23,17 @@ spec:
         - name: out
           persistentVolumeClaim:
             claimName: '{{ "{{inputs.parameters.output-pvc-name}}" }}'
-      {{- $mem := "{{inputs.parameters.memory-mib}}" }}
+      {{- $mem := "{{inputs.parameters.memory-gib}}" }}
       {{- $cpu := "{{inputs.parameters.cpu-m}}" }}
       podSpecPatch: |
         containers:
           - name: main
             resources:
               requests:
-                memory: {{ $mem }}Mi
+                memory: {{ $mem }}Gi
                 cpu: {{ $cpu }}m
               limits:
-                memory: {{ $mem }}Mi
+                memory: {{ $mem }}Gi
                 cpu: {{ $cpu }}m
       script:
         image: us.gcr.io/broad-dsp-gcr-public/xml-to-json-list-clp:{{ $version }}
@@ -44,7 +44,7 @@ spec:
           - name: out
             mountPath: /out
         env:
-          - name: MEM_MIB
+          - name: MEM_GIB
             value: {{ $mem | quote }}
           - name: INPUT
             value: {{ "/in/{{inputs.parameters.input-xml-path}}" }}
@@ -66,6 +66,6 @@ spec:
           fi
 
           # Prevent the heap from consuming all of the pod's memory.
-          declare -r java_mem=$(((${MEM_MIB} - 256)))
-          export JAVA_OPTS="-Xmx${java_mem}m -Xms${java_mem}m"
+          declare -r java_mem=$(((${MEM_GIB} - 1)))
+          export JAVA_OPTS="-Xmx${java_mem}g -Xms${java_mem}g"
           /app/bin/xml-to-json-list-clp ${args[@]}

--- a/argo/templates/template.yaml
+++ b/argo/templates/template.yaml
@@ -44,8 +44,8 @@ spec:
           - name: out
             mountPath: /out
         env:
-          - name: JAVA_OPTS
-            value: '-Xmx{{ $mem }}m -Xms{{ $mem }}m'
+          - name: MEM_MIB
+            value: {{ $mem | quote }}
           - name: INPUT
             value: {{ "/in/{{inputs.parameters.input-xml-path}}" }}
           - name: OBJS_PER_PART
@@ -65,4 +65,7 @@ spec:
             args+=(--gunzip-input)
           fi
 
+          # Prevent the heap from consuming all of the pod's memory.
+          declare -r java_mem=$(((${MEM_MIB} - 256)))
+          export JAVA_OPTS="-Xmx${java_mem}m -Xms${java_mem}m"
           /app/bin/xml-to-json-list-clp ${args[@]}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,4 +14,4 @@ resolvers += Resolver.url(
   new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
 )(publishPatterns)
 
-addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.0.0")
+addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.0.1")


### PR DESCRIPTION
We were giving the JVM the entirety of pod memory to run with, leaving no room for the stack or other off-heap memory.