### PR TITLE
Bump attribute size again

### DIFF
--- a/clp/src/main/scala/org/broadinstitute/monster/extractors/xml/XmlExtractor.scala
+++ b/clp/src/main/scala/org/broadinstitute/monster/extractors/xml/XmlExtractor.scala
@@ -14,6 +14,7 @@ import org.codehaus.jettison.AbstractXMLEventWriter
 import org.codehaus.jettison.badgerfish.BadgerFishXMLStreamWriter
 import org.codehaus.stax2.ri.evt.EndElementEventImpl
 
+import javax.xml.stream.XMLStreamException
 import scala.collection.Iterator
 
 /**
@@ -29,8 +30,8 @@ class XmlExtractor private[xml] (blocker: Blocker)(implicit context: ContextShif
   private val ReaderFactory = new WstxInputFactory()
 
   // the default limit is 524288, which we are running into
-  // this bumps it by a factor of 2
-  private val MaxXmlAttributeSize = 1048576
+  // this bumps it to what the max we have observed + some cushiontemplates/terraform/k8s-node-pool/main.tf
+  private val MaxXmlAttributeSize = 4000000
 
   /**
     * Extract an XML payload into a collection of JSON-list parts,

--- a/clp/src/main/scala/org/broadinstitute/monster/extractors/xml/XmlExtractor.scala
+++ b/clp/src/main/scala/org/broadinstitute/monster/extractors/xml/XmlExtractor.scala
@@ -5,16 +5,14 @@ import cats.data._
 import cats.effect.{Blocker, ContextShift, IO}
 import cats.implicits._
 import com.ctc.wstx.api.WstxInputProperties
-import fs2.{io => _, _}
-
-import javax.xml.stream.events.{Namespace, XMLEvent}
 import com.ctc.wstx.stax.WstxInputFactory
+import fs2.{io => _, _}
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.codehaus.jettison.AbstractXMLEventWriter
 import org.codehaus.jettison.badgerfish.BadgerFishXMLStreamWriter
 import org.codehaus.stax2.ri.evt.EndElementEventImpl
 
-import javax.xml.stream.XMLStreamException
+import javax.xml.stream.events.{Namespace, XMLEvent}
 import scala.collection.Iterator
 
 /**
@@ -30,7 +28,7 @@ class XmlExtractor private[xml] (blocker: Blocker)(implicit context: ContextShif
   private val ReaderFactory = new WstxInputFactory()
 
   // the default limit is 524288, which we are running into
-  // this bumps it to what the max we have observed + some cushiontemplates/terraform/k8s-node-pool/main.tf
+  // this bumps it to what the max we have observed + some cushion
   private val MaxXmlAttributeSize = 4000000
 
   /**


### PR DESCRIPTION
## Why
Clinvar ingest continues to fail due to bumping into data over the max attribute size. I pulled down the offending file and ran it through locally and was able to verify that this value allows the data to flow through. 

## This PR
* Bumps the max attribute size again